### PR TITLE
fixes #4, use defaults for vars, abstract docker cmd name

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -18,7 +18,7 @@ scala_version: 2.11.2
 maven_version: 3.2.5
 
 # Ant
-ant_version: 1.9.4
+ant_version: 1.9.6
 
 # Gradle
 gradle_version: 2.2.1
@@ -44,3 +44,6 @@ ubuntu_keyserver: "keyserver.ubuntu.com"
 ubuntu_keyserver_key: "36A1D7869245C8950F966E92D8576A8BA88D21E9"
 ubuntu_docker_repo: "deb https://get.docker.com/ubuntu docker main"
 ubuntu_ansible_repo: "ppa:ansible/ansible"
+
+# reverse compatibility for docker.io install name
+docker_command: docker.io

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -13,5 +13,5 @@
   sudo: yes
 
 - name: restart docker
-  service: name=docker.io state=restarted
-  sudo: yes  
+  service: name={{ docker_command }} state=restarted
+  sudo: yes

--- a/tasks/docker.yml
+++ b/tasks/docker.yml
@@ -25,14 +25,14 @@
   tags: docker
 
 - name: Create Docker symlink
-  file: src=/usr/bin/docker.io dest=/usr/local/bin/docker state=link force=yes
+  file: src=/usr/bin/{{ docker_command }} dest=/usr/local/bin/docker state=link force=yes
   tags: docker
 
 - name: Add autocomplete
-  command: sed -i '$acomplete -F _docker docker' /etc/bash_completion.d/docker.io
+  command: sed -i '$acomplete -F _docker docker' /etc/bash_completion.d/{{ docker_command }}
   tags: docker
 
 - name: Expose Docker remote api
-  lineinfile: dest=/etc/default/docker.io line='DOCKER_OPTS="-H tcp://127.0.0.1:2375 -H unix:///var/run/docker.sock"' state=present
+  lineinfile: dest=/etc/default/{{ docker_command }} line='DOCKER_OPTS="-H tcp://127.0.0.1:2375 -H unix:///var/run/docker.sock"' state=present
   notify: restart docker
   tags: docker


### PR DESCRIPTION
fixes #4 
defaults/main.yml is much easier to override from higher level playbooks/inventory

Tested on the following Vagrantfile with group vars to override default "docker.io" and setup.yml

``` ruby
VAGRANTFILE_API_VERSION = "2"

Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
  config.vm.box = "ubuntu/trusty64"
  config.vm.network :private_network, ip: "192.168.175.11"

  config.vm.provider :virtualbox do |vb|
    vb.customize ["modifyvm", :id, "--memory", "2048"]
  end

  # Ansible provisioning.
  config.vm.provision "ansible" do |ansible|
    ansible.playbook = "setup.yml"
    ansible.groups = {
        "gocd-server" => ["192.168.175.10"],
        "gocd-agent" => ["default","192.168.175.11"],
    }
    ansible.sudo = true
  end
end
```

``` yml
# setup.yml
--- 
- hosts: all
  roles:
   - gocd-agent
```

``` yml
# group_vars/gocd-agent

---
docker_command: docker
```
